### PR TITLE
Add support for RegExp flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Create a config file `.github/pr-title-checker-config.json` like this one below:
   "CHECKS": {
     "prefixes": ["fix: ", "feat: "],
     "regexp": "docs\\(v[0-9]\\): ",
+    "regexpFlags": "i",
     "ignoreLabels" : ["dont-check-PRs-with-this-label", "meta"]
   }
 }

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ async function run() {
     }
 
     if (CHECKS.regexp) {
-      let re = new RegExp(CHECKS.regexp);
+      let re = new RegExp(CHECKS.regexp, CHECKS.regexpFlags || '');
       if (re.test(title)) {
         removeLabel(LABEL.name);
         return;


### PR DESCRIPTION
Adds support for [RegExp flags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp#parameters), via an optional `CHECKS.regexFlags` configuration option.
This would open use cases like case-insensitive or multiline matches :)