### PR TITLE
Fix a typo in the `remote_configuration_url` input name

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To learn more about workflows, see [Create an example workflow.](https://docs.gi
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pass_on_octokit_error: false
-          remote_configuration_path: "https://raw.githubusercontent.com/grpc/grpc/master/.github/pr_title_checker_config.json"
+          remote_configuration_url: "https://raw.githubusercontent.com/grpc/grpc/master/.github/pr_title_checker_config.json"
 ...
 ```
 Note that this has to be a url pointing to a valid, raw json file. See [#28](https://github.com/thehanimo/pr-title-checker/issues/28)


### PR DESCRIPTION
Hi!

The action is great! Thank you so much for maintaining it.

This fixes a small, but relevant, typo. The name of one of the inputs updated from `remote_configuration_path` to `remote_configuration_url`.

Luckily detected by VS Code (GitHub Actions extension, I guess).