### PR TITLE
Upgrade actions/upload-artifact from v2 to v4

### DIFF
--- a/.github/workflows/check-release-drift.yml
+++ b/.github/workflows/check-release-drift.yml
@@ -39,8 +39,9 @@ jobs:
           fi
         id: diff
       # If index.js was different than expected, upload the unexpected version as an artifact
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist
           path: dist/
+          overwrite: true


### PR DESCRIPTION
Upgrades `actions/upload-artifact` off a deprecated version and to the latest version, as per the [migration guidance](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md).